### PR TITLE
 move “test” run from precommit to CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,11 @@
     "build": "react-scripts build && cp build/index.html build/404.html",
     "lint": "eslint ./src --ext .js,.jsx",
     "test": "react-scripts test --env=jsdom",
-    "test:CI": "cross-env CI=true react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -c src/components/.storybook -p 4000",
     "storybook:build": "build-storybook"
   },
-  "precommit": ["lint", "test:CI"],
+  "precommit": ["lint"],
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.9",
     "@storybook/addon-options": "^3.3.9",


### PR DESCRIPTION
I think as we (eventually) build a suite of tests, we probably don't want them to run every time we commit—but I'm fine with still keeping the lint script for every commit (it doesn't take long to run).

We should be able to push and PR, and then have the tests and build run together in CI, with the deployment failing if either of those fails.